### PR TITLE
Update HighChartsComponent.php

### DIFF
--- a/Controller/Component/HighChartsComponent.php
+++ b/Controller/Component/HighChartsComponent.php
@@ -514,6 +514,7 @@ class HighChartsComponent extends Component {
         }
 
         // Y axis options
+        $this->charts[$name]->yAxis = new stdClass();
         if (isset($params['yAxisMin'])) {
             $this->charts[$name]->yAxis->min = $params['yAxisMin'];
         }


### PR DESCRIPTION
Avoids "Creating default object from empty value" warning error, like what is done for X Axis above.
